### PR TITLE
add option to include config in lambda package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 # Ignore all bundled JS files
 files/deployable/dist/*.js
 files/deployable/dist/*.js.map
+
+# ignore generated config file
+files/deployable/dist/config.json
+
+# ignore node-modules
+files/deployable/node_modules

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Note that if a destroy action is performed on this terraform module, terraform i
 
 In order to properly delete this resource, it should be manually cleaned up, [instructions here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-delete-replicas.html).
 
+### Config shipping
+As noted in [141](https://github.com/disney/terraform-aws-lambda-at-edge-cognito-authentication/issues/141), in regions far remote from `us-east-1`, the edge-auth lambda regularly throws 503's caused by initialisation taking longer than 5 seconds.  The variable `lambda_ship_config` will cause the config for the lambda to be written out as a local file `config.json` that is packaged and shipped with the lambda code.  This has some pros:
+- it significantly reduces the number of round trips required between the edge region and `us-east-1` so lambda initialisation takes a consistent ~1.25s, whereas the default behaviour with the config in SSM can take anywhere from 1.5 to 5+ seconds, which makes the function both more reliable (less 503's) and cheaper.
+and some cons:
+- it means that every config change requires a lambda redeploy - which makes deploys take minutes rather than seconds
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -79,6 +85,7 @@ In order to properly delete this resource, it should be manually cleaned up, [in
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
@@ -97,6 +104,7 @@ No modules.
 | [aws_kms_key.ssm_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_lambda_function.cloudfront_auth_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_ssm_parameter.lambda_configuration_parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [local_file.lambda_configuration](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.install_lambda_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [archive_file.lambda_edge_bundle](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -124,6 +132,7 @@ No modules.
 | <a name="input_cognito_user_pool_name"></a> [cognito\_user\_pool\_name](#input\_cognito\_user\_pool\_name) | Name of the Cognito User Pool to utilize. Required if 'cognito\_user\_pool\_domain' is not set. | `string` | `""` | no |
 | <a name="input_cognito_user_pool_region"></a> [cognito\_user\_pool\_region](#input\_cognito\_user\_pool\_region) | AWS region where the cognito user pool was created. | `string` | `"us-west-2"` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime to utilize for Lambda@Edge. | `string` | `"nodejs20.x"` | no |
+| <a name="input_lambda_ship_config"></a> [lambda\_ship\_config](#input\_lambda\_ship\_config) | Whether to ship the config in the lambda package, or use SSM | `bool` | `false` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Amount of timeout in seconds to set on for Lambda@Edge. | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix on all infrastructure created by this module. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to attach to all AWS resources created by this module. | `map(string)` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -66,29 +66,37 @@ data "aws_iam_policy_document" "allow_lambda_edge_self_role_read" {
 }
 
 resource "aws_iam_role_policy" "ssm_parameter_permission_for_lambda_auth" {
-  name = "SSM_PARAMETER_PERMISSION_FOR_LAMBDA_AUTH"
-  role = aws_iam_role.lambda_at_edge.id
+  count = var.lambda_ship_config ? 0 : 1
+  name  = "SSM_PARAMETER_PERMISSION_FOR_LAMBDA_AUTH"
+  role  = aws_iam_role.lambda_at_edge.id
 
   policy = data.aws_iam_policy_document.allow_ssm_parameter_permission_for_lambda_auth.json
 }
 
 data "aws_iam_policy_document" "allow_ssm_parameter_permission_for_lambda_auth" {
-  statement {
-    actions   = ["ssm:GetParameter"]
-    resources = [aws_ssm_parameter.lambda_configuration_parameters.arn]
+  dynamic "statement" {
+    for_each = var.lambda_ship_config ? [] : [1]
+    content {
+      actions   = ["ssm:GetParameter"]
+      resources = [aws_ssm_parameter.lambda_configuration_parameters[0].arn]
+    }
   }
 }
 
 resource "aws_iam_role_policy" "ssm_parameter_decrypt" {
-  name = "ssmParameterDecrypt"
-  role = aws_iam_role.lambda_at_edge.id
+  count = var.lambda_ship_config ? 0 : 1
+  name  = "ssmParameterDecrypt"
+  role  = aws_iam_role.lambda_at_edge.id
 
   policy = data.aws_iam_policy_document.allow_ssm_parameter_decrypt.json
 }
 
 data "aws_iam_policy_document" "allow_ssm_parameter_decrypt" {
-  statement {
-    actions   = ["kms:Decrypt"]
-    resources = [aws_kms_key.ssm_kms_key.arn]
+  dynamic "statement" {
+    for_each = var.lambda_ship_config ? [] : [1]
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = [aws_kms_key.ssm_kms_key[0].arn]
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "lambda_timeout" {
   default     = 5
 }
 
+variable "lambda_ship_config" {
+  description = "Whether to ship the config in the lambda package, or use SSM"
+  type        = bool
+  default     = false
+}
+
 # ================================================================================================================
 # Cognito @ Edge Configurations
 # ================================================================================================================


### PR DESCRIPTION
the config in SSM in us-east-1 can be slow to access, which causes sporadic 503 errors in regions far from us-east-1. This change adds a variable lambda_ship_config which defaults to false.  If this variable is set to true, the json config will instead be written to a file and packaged/deployed with the lambda code - see the comments in the README for further rationale.

default behaviour is to continue to use SSM, so this should be a non-breaking change.