### PR TITLE
chore: cosmetic fixups to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN for the Lambda@Edge created by this module. |
-| <a name="output_name"></a> [name](#output\_name) | Name of the Lambda@Edge created by this module. |
+| <a name="output_function_name"></a> [name](#output\_function\_name) | Name of the Lambda@Edge created by this module. |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | Qualified ARN for the Lambda@Edge created by this module. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/files/deployable/index.js
+++ b/files/deployable/index.js
@@ -3,7 +3,6 @@ const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
 const { STSClient, GetCallerIdentityCommand } = require('@aws-sdk/client-sts');
 
 const fs = require('fs');
-// Check if the file exists
 const configFile = './config.json';
 
 const NodeCache = require("node-cache");

--- a/output.tf
+++ b/output.tf
@@ -8,7 +8,7 @@ output "arn" {
   value       = aws_lambda_function.cloudfront_auth_edge.arn
 }
 
-output "name" {
+output "function_name" {
   description = "Name of the Lambda@Edge created by this module."
   value       = aws_lambda_function.cloudfront_auth_edge.function_name
 }


### PR DESCRIPTION
I had coders remorse at shortening the output name in the last PR, this
change retains the 1-1 mapping between the outputs of the function and
the underlying resources.